### PR TITLE
Fix "Missing $ inserted" errors with XeTeX

### DIFF
--- a/poster.tex
+++ b/poster.tex
@@ -253,10 +253,10 @@
         \toprule
         \textbf{First column} & \textbf{Second column} & \textbf{Third column} & \textbf{Fourth} \\
         \midrule
-        Foo & 13.37 & 384,394 & \alpha \\
-        Bar & 2.17 & 1,392 & \beta \\
-        Baz & 3.14 & 83,742 & \delta \\
-        Qux & 7.59 & 974 & \gamma \\
+        Foo & 13.37 & 384,394 & $\alpha$ \\
+        Bar & 2.17 & 1,392 & $\beta$ \\
+        Baz & 3.14 & 83,742 & $\delta$ \\
+        Qux & 7.59 & 974 & $\gamma$ \\
         \bottomrule
       \end{tabular}
       \caption{A table caption.}


### PR DESCRIPTION
`\alpha` and friends should only be used inside math, otherwise LaTeX has a tendency to enter math mode unexpectedly which causes mysterious errors like this later on in the document:

```
! Missing $ inserted.
<inserted text> 
                $
l.292 \end{frame}
                 
?
```

(I know the theme is developed for LuaTeX – I can't seem to get it working, though, so I have to use XeTeX.)