### PR TITLE
Uniformisation of block's title spacing

### DIFF
--- a/beamerthemegemini.sty
+++ b/beamerthemegemini.sty
@@ -139,7 +139,7 @@
 \setbeamertemplate{block alerted begin}
 {
   \begin{beamercolorbox}[colsep*=0ex,dp=2ex,center]{block alerted title}
-    \vskip0.5ex
+    \vskip0pt
     \usebeamerfont{block title}\insertblocktitle
     \vskip-1.25ex
     \begin{beamercolorbox}[colsep=0.025ex]{block alerted separator}\end{beamercolorbox}


### PR DESCRIPTION
While producing a poster with this template, which is beautiful and perfect for what I need, I encountered a small alignment bug with the titles of blocks. In fact, the line of alert blocks seemed a little bit off compared to the line of normal blocks, when compared from the top of the body frame. Setting the first \vskip of alert blocks to 0pt seems to solve this problem.

Here is a working example of this problem (compare blocks at the top of the page).
[Poster_alignement.zip](https://github.com/anishathalye/gemini/files/3624283/Poster_alignement.zip)
[poster.pdf](https://github.com/anishathalye/gemini/files/3624286/poster.pdf)
Poster after this fix :
[poster.pdf](https://github.com/anishathalye/gemini/files/3624309/poster.pdf)