### PR TITLE
add [Ligatures=TeX] option to fonts

### DIFF
--- a/beamerthemegemini.sty
+++ b/beamerthemegemini.sty
@@ -14,8 +14,8 @@
 % Fonts
 % ====================
 
-\newfontfamily\Raleway{Raleway}
-\newfontfamily\Lato{Lato}
+\newfontfamily\Raleway[Ligatures=TeX]{Raleway}
+\newfontfamily\Lato[Ligatures=TeX]{Lato}
 
 \usefonttheme{professionalfonts}
 


### PR DESCRIPTION
When I tried to use things like `---` to create a long dash (—), it just printed three separate dashes in this beamerposter theme. I added the `Ligatures=TeX` option for the two fonts to fix this.