### PR TITLE
add optional footer

### DIFF
--- a/beamerthemegemini.sty
+++ b/beamerthemegemini.sty
@@ -33,6 +33,7 @@
 \setbeamerfont{block title}{family=\Raleway,size=\large,series=\bfseries}
 \setbeamerfont{heading}{family=\Lato,series=\bfseries}
 \setbeamerfont{caption}{size=\small}
+\setbeamerfont{footline}{family=\Raleway,size=\normalsize}
 
 % ====================
 % Macros
@@ -160,4 +161,24 @@
   \end{beamercolorbox}
   \vskip0pt
   \vspace*{2ex}
+}
+
+% Footer
+\newcommand{\footercontent}[1]{\newcommand{\insertfootercontent}{#1}}
+
+\setbeamertemplate{footline}{
+	\ifdefined\insertfootercontent
+		\begin{beamercolorbox}[vmode]{headline}
+			\ifbeamercolorempty[bg]{headline rule}{}{
+				\begin{beamercolorbox}[wd=\paperwidth,colsep=0.25ex]{headline rule}\end{beamercolorbox}
+			}
+			\vspace{0.5ex}
+			\hspace{\sepwidth}
+			\usebeamerfont{footline}
+			\centering
+			\insertfootercontent
+			\hspace{\sepwidth}
+			\vspace{1.25ex}
+		\end{beamercolorbox}
+	\else\fi
 }

--- a/poster.tex
+++ b/poster.tex
@@ -41,6 +41,16 @@
 \institute[shortinst]{\inst{1} Some Institute \samelineand \inst{2} Another Institute}
 
 % ====================
+% Footer (optional)
+% ====================
+
+\footercontent{
+  \href{http://www.example.com}{http://www.example.com} \hfill
+  ABC Conference 2025, New York --- XYZ-1234 \hfill
+  \href{alyssa.hacker@example.com}{alyssa.hacker@example.com}}
+% (can be left out to remove footer)
+
+% ====================
 % Body
 % ====================
 


### PR DESCRIPTION
This is a proposal to add an optional footer to the poster, where things like a conference name, a poster/abstract number, and contact information can be included.

![poster](https://user-images.githubusercontent.com/5310424/66475182-1b435380-ea93-11e9-8a4a-927c33946b1b.png)

Currently, the footer content is fully customizable using the `\footercontent` command. If `\footercontent`  is left out, the footer is not drawn. I could also define some fixed fields like `\footerleft`, `\footercenter` and `\footerright` instead if you would like.