### PR TITLE
New way to include logos

### DIFF
--- a/beamerthemegemini.sty
+++ b/beamerthemegemini.sty
@@ -103,13 +103,13 @@
 \newcommand{\logoright}[1]{
   \newcommand{\insertlogoright}{#1}
   \settowidth{\logorightwidth}{\insertlogoright}
-  \addtolength{\logorightwidth}{2cm}
+  \addtolength{\logorightwidth}{5ex}
   \setlength{\maxlogowidth}{\maxof{\logoleftwidth}{\logorightwidth}}
 }
 \newcommand{\logoleft}[1]{
   \newcommand{\insertlogoleft}{#1}
   \settowidth{\logoleftwidth}{\insertlogoleft}
-  \addtolength{\logoleftwidth}{2cm}
+  \addtolength{\logoleftwidth}{5ex}
   \setlength{\maxlogowidth}{\maxof{\logoleftwidth}{\logorightwidth}}
 }
 
@@ -119,9 +119,13 @@
   \begin{beamercolorbox}{headline}
     \begin{columns}
       \begin{column}{\maxlogowidth}
-        \centering
+        \vskip5ex
         \ifdefined\insertlogoleft
+        \vspace*{\fill}
+        \hspace{5ex}
+        \raggedright
         \insertlogoleft
+        \vspace*{\fill}
         \else\fi
       \end{column}
       \begin{column}{\dimexpr\paperwidth-\maxlogowidth-\maxlogowidth}
@@ -133,9 +137,13 @@
         {\usebeamerfont{headline institute}\usebeamercolor[fg]{headline institute}\insertinstitute\\[1ex]}
       \end{column}
       \begin{column}{\maxlogowidth}
-        \centering
+        \vskip5ex
         \ifdefined\insertlogoright
+        \vspace*{\fill}
+        \raggedleft
         \insertlogoright
+        \hspace{5ex}
+        \vspace*{\fill}
         \else\fi
       \end{column}
     \end{columns}

--- a/beamerthemegemini.sty
+++ b/beamerthemegemini.sty
@@ -9,6 +9,7 @@
 \RequirePackage{ragged2e}
 \RequirePackage{changepage}
 \RequirePackage{fontspec}
+\RequirePackage{calc}
 
 % ====================
 % Fonts
@@ -91,18 +92,51 @@
   {\usebeamerfont{heading}\usebeamercolor[fg]{heading}#1}\par\smallskip
 }
 
+% logo
+\newlength{\logoleftwidth}
+\setlength{\logoleftwidth}{0cm}
+\newlength{\logorightwidth}
+\setlength{\logorightwidth}{0cm}
+\newlength{\maxlogowidth}  % space on both sides set to maxlogowidth to keep title centered
+\setlength{\maxlogowidth}{0cm}
+
+\newcommand{\logoright}[1]{
+  \newcommand{\insertlogoright}{#1}
+  \settowidth{\logorightwidth}{\insertlogoright}
+  \addtolength{\logorightwidth}{2cm}
+  \setlength{\maxlogowidth}{\maxof{\logoleftwidth}{\logorightwidth}}
+}
+\newcommand{\logoleft}[1]{
+  \newcommand{\insertlogoleft}{#1}
+  \settowidth{\logoleftwidth}{\insertlogoleft}
+  \addtolength{\logoleftwidth}{2cm}
+  \setlength{\maxlogowidth}{\maxof{\logoleftwidth}{\logorightwidth}}
+}
+
 % Headline
 \setbeamertemplate{headline}
 {
   \begin{beamercolorbox}{headline}
     \begin{columns}
-      \begin{column}{\paperwidth}
+      \begin{column}{\maxlogowidth}
+        \centering
+        \ifdefined\insertlogoleft
+        \insertlogoleft
+        \else\fi
+      \end{column}
+      \begin{column}{\dimexpr\paperwidth-\maxlogowidth-\maxlogowidth}
         \usebeamerfont{headline}
         \vskip3ex
         \centering
         {\usebeamerfont{headline title}\usebeamercolor[fg]{headline title}\inserttitle\\[0.5ex]}
         {\usebeamerfont{headline author}\usebeamercolor[fg]{headline author}\insertauthor\\[1ex]}
         {\usebeamerfont{headline institute}\usebeamercolor[fg]{headline institute}\insertinstitute\\[1ex]}
+      \end{column}
+      \begin{column}{\maxlogowidth}
+        \centering
+        \ifdefined\insertlogoright
+        \insertlogoright
+        \else\fi
       \end{column}
     \end{columns}
     \vspace{5ex}

--- a/poster.tex
+++ b/poster.tex
@@ -51,6 +51,14 @@
 % (can be left out to remove footer)
 
 % ====================
+% Logo (optional)
+% ====================
+
+% use this to include logos on the left and/or right side of the header:	
+% \logoright{\includegraphics[height=7cm]{logo1.pdf}}
+% \logoleft{\includegraphics[height=7cm]{logo2.pdf}}
+
+% ====================
 % Body
 % ====================
 


### PR DESCRIPTION
This defines two new commands `\logoleft` and `\logoright` that allow the user to easily include one or two institution logos on the left or right side of the header. In contrast to the previous solution with tikz overlays (#4), this ensures that the logo does not overlap with the title and/or authors (in case the title is very long or the number of coauthors very large).

I'm not sure if we should add additional spacing around the logos or leave this to the user to configure (as it could depend on whether there's already some space within the logo image).