### PR TITLE
Updated the MIT theme to include a suitable example block

### DIFF
--- a/beamercolorthememit.sty
+++ b/beamercolorthememit.sty
@@ -12,7 +12,7 @@
 
 % Extra colors
 \definecolor{lightgray}{RGB}{240, 240, 240}
-
+\definecolor{lightorange}{RGB}{255, 235, 230}
 % ====================
 % Theme
 % ====================
@@ -36,6 +36,11 @@
 \setbeamercolor{block alerted title}{fg=mitred,bg=lightgray}
 \setbeamercolor{block alerted separator}{bg=black}
 \setbeamercolor{block alerted body}{fg=black,bg=lightgray}
+
+% Example Block
+\setbeamercolor{block example title}{fg=mitred,bg=lightorange}
+\setbeamercolor{block example separator}{bg=black}
+\setbeamercolor{block example body}{fg=black,bg=lightorange}
 
 % Heading
 \setbeamercolor{heading}{fg=black}


### PR DESCRIPTION
This change will allow us to create an example block that is slightly reddish in colour. Useful for highlighting other information (to distinguish it from an alert box)