### PR TITLE
Fix newline issue with bib entries

### DIFF
--- a/beamercolorthemegemini.sty
+++ b/beamercolorthemegemini.sty
@@ -46,3 +46,7 @@
 \setbeamercolor{bibliography entry title}{fg=black}
 \setbeamercolor{bibliography entry location}{fg=black}
 \setbeamercolor{bibliography entry note}{fg=black}
+\setbeamertemplate{bibliography entry article}{}
+\setbeamertemplate{bibliography entry title}{}
+\setbeamertemplate{bibliography entry location}{}
+\setbeamertemplate{bibliography entry note}{}


### PR DESCRIPTION
Without this patch, the entries in the references box contain unnecessary newlines after the author and title.