### PR TITLE
Fix math font warnings

### DIFF
--- a/poster.tex
+++ b/poster.tex
@@ -17,6 +17,7 @@
 \usepackage{tikz}
 \usepackage{pgfplots}
 \pgfplotsset{compat=1.14}
+\usepackage{fixcmex}
 
 % ====================
 % Lengths


### PR DESCRIPTION
To remove
```
LaTeX Font Warning: Font shape `OMX/cmex/m/n' in size <35.83> not available
(Font)              size <24.88> substituted on input line 66.


LaTeX Font Warning: Font shape `OMX/cmex/m/n' in size <17.915> not available
(Font)              size <17.28> substituted on input line 66.

 [1]

LaTeX Font Warning: Size substitutions with differences
(Font)              up to 10.95pt have occurred.
```

See https://ctan.org/pkg/fixcmex