### PR TITLE
Replace `\leftmarginii` with `\leftmargini` for first level lists

### DIFF
--- a/beamerthemegemini.sty
+++ b/beamerthemegemini.sty
@@ -47,7 +47,7 @@
 % ====================
 
 % List
-\def\@listi{\leftmargin\leftmarginii
+\def\@listi{\leftmargin\leftmargini
 \topsep 1ex % spacing before
 \parsep 0\p@ \@plus\p@
 \itemsep 0.5ex} % spacing between


### PR DESCRIPTION
- beamer uses `\leftmargini` for first level lists https://github.com/josephwright/beamer/blob/a9b7aefd30d6a46824de01a5220209045c2c7f7d/base/beamerbaselocalstructure.sty#L151 Your users will be used to change this parameter to adjust the indentation
- this will also allow your users to modify the indentation of first and second level lists separately
- fix #33