### PR TITLE
University of Bristol theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The community has also contributed a number of themes:
 
 - `dart` ([Dartmouth College](https://dartmouth.edu))
 - `umich` ([University of Michigan](https://umich.edu/))
+- `bristol` ([University of Bristol](https://www.bristol.ac.uk/))
 
 If you create a Gemini theme, feel free to send a pull request to add it here!
 

--- a/beamercolorthemebristol.sty
+++ b/beamercolorthemebristol.sty
@@ -1,0 +1,72 @@
+% Gemini theme
+% https://github.com/anishathalye/gemini
+
+% ====================
+% Definitions
+% ====================
+
+% see https://www.bristol.ac.uk/style-guides/brand-identity/
+\definecolor{bristolred}{RGB}{171, 31, 45}
+\definecolor{bristolcoolgray}{RGB}{227, 230, 229}
+
+\definecolor{bristolredlight}{RGB}{243, 190, 196}
+
+\definecolor{bristolbrightblue}{RGB}{12, 198, 222}
+\definecolor{bristoldarkblue}{RGB}{0, 47, 95}
+
+\definecolor{bristolbrightaqua}{RGB}{0, 192, 181}
+\definecolor{bristolbrightorange}{RGB}{238, 114, 25}
+\definecolor{bristolbrightpurple}{RGB}{146, 120, 209}
+\definecolor{bristolbrightpink}{RGB}{224, 36, 154}
+
+
+% Extra colors
+\definecolor{lightgray}{RGB}{240, 240, 240}
+\definecolor{lightorange}{RGB}{255, 245, 242}
+
+% ====================
+% Theme
+% ====================
+
+% Basic colors
+\setbeamercolor{palette primary}{fg=black,bg=white}
+\setbeamercolor{palette secondary}{fg=black,bg=white}
+\setbeamercolor{palette tertiary}{bg=black,fg=white}
+\setbeamercolor{palette quaternary}{fg=black,bg=white}
+\setbeamercolor{structure}{fg=bristolred}
+
+% Headline
+\setbeamercolor{headline}{fg=white,bg=bristolred}
+
+% Block
+\setbeamercolor{block title}{fg=bristolred,bg=white}
+\setbeamercolor{block separator}{bg=black}
+\setbeamercolor{block body}{fg=black,bg=white}
+
+% Alert Block - White Text, Solid Red Background
+\setbeamercolor{block alerted title}{fg=white,bg=bristolred}
+\setbeamercolor{block alerted separator}{bg=white}
+\setbeamercolor{block alerted body}{fg=white,bg=bristolred}
+
+% Alert Block - Black Text, Light Red Background
+% \setbeamercolor{block alerted title}{fg=black,bg=bristolredlight}
+% \setbeamercolor{block alerted separator}{bg=black}
+% \setbeamercolor{block alerted body}{fg=black,bg=bristolredlight}
+
+% Example Block
+\setbeamercolor{block example title}{fg=bristolred,bg=lightgray}
+\setbeamercolor{block example separator}{bg=black}
+\setbeamercolor{block example body}{fg=black,bg=lightgray}
+
+% Heading
+\setbeamercolor{heading}{fg=black}
+
+% Itemize
+\setbeamercolor{item}{fg=bristolred}
+
+% Bibliography
+\setbeamercolor{bibliography item}{fg=black}
+\setbeamercolor{bibliography entry author}{fg=black}
+\setbeamercolor{bibliography entry title}{fg=black}
+\setbeamercolor{bibliography entry location}{fg=black}
+\setbeamercolor{bibliography entry note}{fg=black}

--- a/beamercolorthemebristol.sty
+++ b/beamercolorthemebristol.sty
@@ -6,6 +6,7 @@
 % ====================
 
 % see https://www.bristol.ac.uk/style-guides/brand-identity/
+% logos are also available in the bristol-theme fork: https://github.com/sambowyer/gemini_bristol
 \definecolor{bristolred}{RGB}{171, 31, 45}
 \definecolor{bristolcoolgray}{RGB}{227, 230, 229}
 


### PR DESCRIPTION
Added a University of Bristol colour theme using the uni's style guide https://www.bristol.ac.uk/style-guides/brand-identity/.

Example compiled poster with logo:
[poster.pdf](https://github.com/user-attachments/files/21059085/poster.pdf)
![poster](https://github.com/user-attachments/assets/7c9deb81-b302-4572-aafb-e84d49448c7a)

Thanks!
