### PR TITLE
Create a new color theme for Seoul National University

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The community has also contributed a number of themes:
 - `umich` ([University of Michigan](https://umich.edu/))
 - `bristol` ([University of Bristol](https://www.bristol.ac.uk/))
 - `warwick` ([University of Warwick](https://warwick.ac.uk/))
+- `snu` ([Seoul National University](https://snu.ac.kr))
 
 If you create a Gemini theme, feel free to send a pull request to add it here!
 

--- a/beamercolorthemesnu.sty
+++ b/beamercolorthemesnu.sty
@@ -5,7 +5,8 @@
 % Definitions
 % ====================
 
-% Colors from https://identity.snu.ac.kr/color/1
+% Colors from https://identity.snu.ac.kr/
+% Logos are also available in https://identity.snu.ac.kr/
 \definecolor{snublue}{cmyk}{0.87, 0.85, 0.0, 0.56} % #0f0f70
 \definecolor{snugray}{cmyk}{0.0, 0.0, 0.0, 0.60} % #666666
 \definecolor{snubeige}{cmyk}{0.13, 0.10, 0.25, 0.0} % #DEE6BF

--- a/beamercolorthemesnu.sty
+++ b/beamercolorthemesnu.sty
@@ -1,0 +1,57 @@
+% Gemini theme
+% https://github.com/anishathalye/gemini
+
+% ====================
+% Definitions
+% ====================
+
+% Colors from https://identity.snu.ac.kr/color/1
+\definecolor{snublue}{cmyk}{0.87, 0.85, 0.0, 0.56} % #0f0f70
+\definecolor{snugray}{cmyk}{0.0, 0.0, 0.0, 0.60} % #666666
+\definecolor{snubeige}{cmyk}{0.13, 0.10, 0.25, 0.0} % #DEE6BF
+\definecolor{snugold}{cmyk}{0.0, 0.20, 0.44, 0.45} % #8B6F4E
+\definecolor{snuwhite}{cmyk}{0.03, 0.01, 0.0, 0.44} % #8A8D8F
+\definecolor{snuwhite}{cmyk}{0.0, 0.0, 0.0, 0.0} % #FFFFFF
+
+% ====================
+% Theme
+% ====================
+
+% Basic colors
+\setbeamercolor{palette primary}{fg=snublue,bg=snuwhite}
+\setbeamercolor{palette secondary}{fg=snublue,bg=snuwhite}
+\setbeamercolor{palette tertiary}{bg=snublue,fg=snuwhite}
+\setbeamercolor{palette quaternary}{fg=snublue,bg=snuwhite}
+\setbeamercolor{structure}{fg=snublue}
+
+% Headline
+\setbeamercolor{headline}{fg=snuwhite,bg=snublue}
+\setbeamercolor{headline rule}{bg=snugold}
+
+% Block
+\setbeamercolor{block title}{fg=snublue,bg=snuwhite}
+\setbeamercolor{block separator}{bg=snublue}
+\setbeamercolor{block body}{fg=snublue,bg=snuwhite}
+
+% Alert Block
+\setbeamercolor{block alerted title}{fg=snublue,bg=snubeige}
+\setbeamercolor{block alerted separator}{bg=snublue}
+\setbeamercolor{block alerted body}{fg=snublue,bg=snubeige}
+
+% Example Block
+\setbeamercolor{block example title}{fg=snublue,bg=snuwhite}
+\setbeamercolor{block example separator}{bg=snublue}
+\setbeamercolor{block example body}{fg=snublue,bg=snuwhite}
+
+% Heading
+\setbeamercolor{heading}{fg=snublue}
+
+% Itemize
+\setbeamercolor{item}{fg=snublue}
+
+% Bibliography
+\setbeamercolor{bibliography item}{fg=snublue}
+\setbeamercolor{bibliography entry author}{fg=snublue}
+\setbeamercolor{bibliography entry title}{fg=snublue}
+\setbeamercolor{bibliography entry location}{fg=snublue}
+\setbeamercolor{bibliography entry note}{fg=snublue}


### PR DESCRIPTION
Added a color theme for Seoul National University (following the style guide on https://identity.snu.ac.kr).

<img width="799" height="487" alt="poster" src="https://github.com/user-attachments/assets/62d0c20f-7d5f-4221-bbfd-5063782f00bd" />

A compiled example: 
[poster.pdf](https://github.com/user-attachments/files/21767008/poster.pdf)
