### PR TITLE
Templates assume definition of \sepwidth

### DIFF
--- a/beamerthemegemini.sty
+++ b/beamerthemegemini.sty
@@ -250,11 +250,11 @@
       \begin{beamercolorbox}[wd=\paperwidth,colsep=0.25ex]{headline rule}\end{beamercolorbox}
     }
     \vspace{1.5ex}
-    \hspace{\sepwidth}
+    \hspace{\hfill}
     \usebeamerfont{footline}
     \centering
     \insertfootercontent
-    \hspace{\sepwidth}
+    \hspace{\hfill}
     \vspace{1.5ex}
   \end{beamercolorbox}
   \else\fi


### PR DESCRIPTION
If `\sepwidth` is not defined in the main latex file, this template will produce an error.

Most beamer templates online do have `\sepwidth` defined, so as simple option would be to just update the documentation. Otherwise, the template could define a default value, or instead fill, as suggested here. However, this is not exactly preserving existing files. Thoughts?